### PR TITLE
Add easy ability to set status codes and format response body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 src/*.o
 *.o
 .cache/
+*swp*

--- a/include/HTTP_Server.h
+++ b/include/HTTP_Server.h
@@ -1,11 +1,44 @@
 #ifndef HTTP_SERVER_H
 #define HTTP_SERVER_H
 
+#include <string.h>
+#include <stddef.h>
+
+#define HTTP_STATUS_CODE_LEN 50
+#define HTTP_RESPONSE_BODY_LEN 4096
+
+// note: please keep these in the same order as _status_code_text
+// as that's the corresponding lookup table
+enum http_status_code_e
+{
+	OK = 0,
+	CREATED,
+	BAD_REQUEST,
+	UNAUTHORIZED,
+	FORBIDDEN,
+	NOT_FOUND,
+	INTERNAL_ERROR,
+	NOT_IMPLEMENTED
+};
+
+// defined in HTTP_Server.c
+extern const char _status_code_text[8][50];
+
 typedef struct HTTP_Server {
 	int socket;
 	int port;	
+	char status_code[HTTP_STATUS_CODE_LEN];
+	char response[HTTP_RESPONSE_BODY_LEN];
 } HTTP_Server;
 
 void init_server(HTTP_Server* http_server, int port);
+
+void http_set_status_code(
+		HTTP_Server* http_server, 
+		const enum http_status_code_e);
+
+void http_set_response_body(
+		HTTP_Server* http_server,
+		const char* body);
 
 #endif

--- a/src/HTTP_Server.c
+++ b/src/HTTP_Server.c
@@ -10,7 +10,7 @@ const char _status_code_text[8][50] = {
 	"HTTP/1.1 400 Bad request\r\n\r\n",
 	"HTTP/1.1 401 Unauthorized\r\n\r\n",
 	"HTTP/1.1 403 Forbidden\r\n\r\n",
-	"HTTP/1.1 401 Not found\r\n\r\n",
+	"HTTP/1.1 404 Not found\r\n\r\n",
 	"HTTP/1.1 500 Internal Error\r\n\r\n",
 	"HTTP/1.1 501 Not implemented\r\n\r\n"
 };

--- a/src/HTTP_Server.c
+++ b/src/HTTP_Server.c
@@ -3,6 +3,18 @@
 #include <stdio.h>
 #include <sys/socket.h>
 
+// pulled these from https://www.w3.org/Protocols/HTTP/HTRESP.html
+const char _status_code_text[8][50] = {
+	"HTTP/1.1 200 OK\r\n\r\n",
+	"HTTP/1.1 201 CREATED\r\n\r\n",
+	"HTTP/1.1 400 Bad request\r\n\r\n",
+	"HTTP/1.1 401 Unauthorized\r\n\r\n",
+	"HTTP/1.1 403 Forbidden\r\n\r\n",
+	"HTTP/1.1 401 Not found\r\n\r\n",
+	"HTTP/1.1 500 Internal Error\r\n\r\n",
+	"HTTP/1.1 501 Not implemented\r\n\r\n"
+};
+
 void init_server(HTTP_Server * http_server, int port) {
 	http_server->port = port;
 
@@ -19,4 +31,28 @@ void init_server(HTTP_Server * http_server, int port) {
 
 	http_server->socket = server_socket;
 	printf("HTTP Server Initialized\nPort: %d\n", http_server->port);
+}
+
+void http_set_status_code(
+		HTTP_Server* http_server,
+		const enum http_status_code_e status_code)
+{
+	memset(http_server->status_code, 0, HTTP_STATUS_CODE_LEN);
+	const char* _status = _status_code_text[status_code];
+	memcpy(http_server->status_code, _status, strlen(_status));
+}
+
+void http_set_response_body(
+		HTTP_Server* http_server,
+		const char* body)
+{
+	// prepend the status code before adding the body
+	memset(http_server->response, 0, HTTP_RESPONSE_BODY_LEN);
+	memcpy(http_server->response, http_server->status_code, strlen(http_server->status_code));
+
+	// add response body (while accounting for the space we already took up by the response code
+	// NOTE: the -5 is for the four extra \r\n\r\n characters and a null terminator
+	size_t max_len = (size_t)HTTP_RESPONSE_BODY_LEN - strlen(http_server->status_code) - 5;
+	strncat(http_server->response, body, max_len);
+	strncat(http_server->response, "\r\n\r\n", 5);
 }

--- a/src/Response.c
+++ b/src/Response.c
@@ -23,6 +23,7 @@ char * render_static_file(char * fileName) {
 		temp[i] = ch;
 		i++;
 	}
+	temp[i] = '\0';
 	fclose(file);
 	return temp;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -25,7 +25,7 @@ int main() {
 
 
 	printf("\n====================================\n");
-	printf("=========ALL VAILABLE ROUTES========\n");
+	printf("=========ALL AVAILABLE ROUTES========\n");
 	// display all available routes
 	inorder(route);
 
@@ -70,26 +70,24 @@ int main() {
 		if (strstr(urlRoute, "/static/") != NULL) {
 			//strcat(template, urlRoute+1);
 			strcat(template, "static/index.css");
+			http_set_status_code(&http_server, OK);
 		}else {
 			struct Route * destination = search(route, urlRoute);
 			strcat(template, "templates/");
 
 			if (destination == NULL) {
 				strcat(template, "404.html");
+				http_set_status_code(&http_server, NOT_FOUND);
 			}else {
 				strcat(template, destination->value);
+				http_set_status_code(&http_server, OK);
 			}
 		}
 
 		char * response_data = render_static_file(template);
+		http_set_response_body(&http_server, response_data);
 
-		char http_header[4096] = "HTTP/1.1 200 OK\r\n\r\n";
-
-		strcat(http_header, response_data);
-		strcat(http_header, "\r\n\r\n");
-
-
-		send(client_socket, http_header, sizeof(http_header), 0);
+		send(client_socket, http_server.response, sizeof(http_server.response), 0);
 		close(client_socket);
 		free(response_data);
 	}


### PR DESCRIPTION
I did this PR independent of my other PR, #4 since I didn't know which one would be merged first (if any) to avoid complicating things. This is a rebase of the master branch (at the time).

I modified the `HTTP_Server` struct a bit to hold the status code and the response body. This comes with two new functions:

Set the the status code using any of the pre-defined enums (listed below)
```c
void http_set_status_code(
    HTTP_Server* http_server, 
    const enum http_status_code_e);

// example
http_set_status_code(&http_server, OK);
```

Prepare the response body before sending to the client (see `main.c` for the full example usage). This will automatically prepend the status code for us so we don't have to manually `strncat` it ourselves.
```c
void http_set_response_body(
    HTTP_Server* http_server,
    const char* body);
```

As of now the following status codes are supported:
```text
200 OK
201 CREATED
400 Bad request
401 Unauthorized
403 Forbidden
404 Not found
500 Internal Error
501 Not implemented
```

I didn't add all of them, just what I feel like are probably the most common ones (it's easy enough to change in the future).

See the attached video sample where I tested the `OK` and `NOT_FOUND` status codes after slight modifications to the `main.c` example.


https://user-images.githubusercontent.com/49159969/213949259-51debc5d-ae68-493d-9257-c1696384a97d.mp4

